### PR TITLE
chore: fix trivial SonarQube code smells

### DIFF
--- a/src/main/java/com/github/zrdj/java/predicates/collections/CollectionPredicates.java
+++ b/src/main/java/com/github/zrdj/java/predicates/collections/CollectionPredicates.java
@@ -85,7 +85,7 @@ public interface CollectionPredicates {
 
         @Override
         public <T> Predicate<Collection<T>> containsAllOf(T[] elements) {
-            return outer -> containsAllOf(Arrays.asList((T[]) elements)).test(outer);
+            return outer -> containsAllOf(Arrays.asList(elements)).test(outer);
         }
 
         @Override
@@ -95,7 +95,7 @@ public interface CollectionPredicates {
 
         @Override
         public <T> Predicate<Collection<T>> containsAnyOf(T[] elements) {
-            return outer -> containsAnyOf(Arrays.asList((T[]) elements)).test(outer);
+            return outer -> containsAnyOf(Arrays.asList(elements)).test(outer);
         }
 
         @Override
@@ -105,7 +105,7 @@ public interface CollectionPredicates {
 
         @Override
         public <T> Predicate<Collection<T>> containsNoneOf(T[] elements) {
-            return outer -> containsNoneOf(Arrays.asList((T[]) elements)).test(outer);
+            return outer -> containsNoneOf(Arrays.asList(elements)).test(outer);
         }
 
         @Override

--- a/src/main/java/com/github/zrdj/java/predicates/helper/Throws.java
+++ b/src/main/java/com/github/zrdj/java/predicates/helper/Throws.java
@@ -1,6 +1,8 @@
 package com.github.zrdj.java.predicates.helper;
 
-public abstract class Throws {
+public final class Throws {
+    private Throws() {}
+
     public static boolean exception(final Action action) {
         try {
             action.execute();


### PR DESCRIPTION
## Summary

Fixes 4 open SonarQube issues across 2 rules:

- **java:S1905** (unnecessary cast) — 3 occurrences in `CollectionPredicates.Default`: removed redundant `(T[])` cast in `containsAllOf(T[])`, `containsAnyOf(T[])`, and `containsNoneOf(T[])` (lines 88, 98, 108). The varargs parameters are already typed as `T[]`.
- **java:S1118** (missing private constructor) — 1 occurrence in `Throws`: changed `abstract class` to `final class` and added `private Throws() {}` to prevent implicit public constructor and accidental subclassing. Public static API is unchanged.

## Rules NOT touched (explicitly excluded per task)
- `java:S1117` (variable shadowing) — 5 issues in test code, left untouched
- `java:S1135` (TODO comments) — 3 issues, left untouched

## Test plan
- [x] `mvn -q -DskipTests compile` passes inside devcontainer (no errors, JVM warnings only)
- [ ] Full test suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)